### PR TITLE
Removing the master-slave words

### DIFF
--- a/pyHegel/cryomech.py
+++ b/pyHegel/cryomech.py
@@ -248,7 +248,7 @@ class Cryomech(object):
         """ questions:
               3: Product ID
               4: Software version
-              5: Reset slave
+              5: Reset subordinate
               6: Acknowledge power fail
               7: Protocol stack version
               9: Obtain compressor display

--- a/pyHegel/instruments/agilent.py
+++ b/pyHegel/instruments/agilent.py
@@ -1991,7 +1991,7 @@ register_usb_name('PNA network analyser', 0x0957, 0x0118)
 #       *ESE     To set/query the bit flag that toggles bit 5 of IEEE status
 # For IEEE status: contains :operation (bit 7), :questionable (bit 3)
 #                           event (bit 5), error (bit 2), message available (bit 4)
-#                           Request Service =RQS (bit 6) also MSS (master summary) which
+#                           Request Service =RQS (bit 6) also MSS (main summary) which
 #                                     is instantenous RQS. RQS is latched
 #                           Not that first bit is bit 0
 # To read error (bit 2): v.ask(':system:error?')

--- a/pyHegel/instruments/lecroy.py
+++ b/pyHegel/instruments/lecroy.py
@@ -515,15 +515,15 @@ class lecroy_vbs_scpi(scpiDevice):
         super(lecroy_vbs_scpi,self).__init__(setstr, getstr, *arg, autoget=autoget, **kwarg)
 
 #######################################################
-##    LeCroy WaveMaster 820Zi-A
+##    LeCroy WaveMain 820Zi-A
 #######################################################
 
-#@register_instrument('LECROY', 'WM820ZI-A', '7.2.1', alias='WM820ZI-A WaveMaster scope')
-#@register_instrument('LECROY', 'WM820ZI-A', '7.8.0', alias='WM820ZI-A WaveMaster scope')
-@register_instrument('LECROY', 'WM820ZI-A', alias='WM820ZI-A WaveMaster scope')
-class lecroy_wavemaster(visaInstrumentAsync):
+#@register_instrument('LECROY', 'WM820ZI-A', '7.2.1', alias='WM820ZI-A WaveMain scope')
+#@register_instrument('LECROY', 'WM820ZI-A', '7.8.0', alias='WM820ZI-A WaveMain scope')
+@register_instrument('LECROY', 'WM820ZI-A', alias='WM820ZI-A WaveMain scope')
+class lecroy_wavemain(visaInstrumentAsync):
     """
-    This instrument controls a LeCroy WaveMaster 820Zi-A
+    This instrument controls a LeCroy WaveMain 820Zi-A
      To use this instrument, the most useful devices are probably:
        fetch
        readval
@@ -546,7 +546,7 @@ class lecroy_wavemaster(visaInstrumentAsync):
         # open Interrupt channel port)
         self._trigmode_mode = None
         self._trigmode_avgn = None
-        super(lecroy_wavemaster, self).__init__(visa_addr, poll=True)
+        super(lecroy_wavemain, self).__init__(visa_addr, poll=True)
         response = self.ask('Reference_CLocK?')
         if response in  ['WARNING : CURRENT REMOTE CONTROL INTERFACE IS TCPIP',
                          'WARNING : CURRENT REMOTE CONTROL INTERFACE IS LSIB',
@@ -556,7 +556,7 @@ class lecroy_wavemaster(visaInstrumentAsync):
         self.write('Comm_ORDer LO') # can be LO or HI: LO=LSB first
         self.write('Comm_ForMaT DEF9,WORD,BIN') #DEF9=IEEE 488.2 block data, WORD (default is BYTE)
         self.write('Comm_HeaDeR OFF') #can be OFF, SHORT, LONG. OFF removes command echo and units
-        super(lecroy_wavemaster, self).init(full=full)
+        super(lecroy_wavemain, self).init(full=full)
     @locked_calling
     def _current_config(self, dev_obj=None, options={}):
         ch_info = []
@@ -697,12 +697,12 @@ class lecroy_wavemaster(visaInstrumentAsync):
         if use_vbs:
             self.vbs_write(command)
         else:
-            super(lecroy_wavemaster, self).write(command)
+            super(lecroy_wavemain, self).write(command)
     def ask(self, command, raw=False, chunk_size=None, use_vbs=False):
         if use_vbs:
             return self.vbs_ask(command)
         else:
-            return super(lecroy_wavemaster, self).ask(command, raw=raw, chunk_size=chunk_size)
+            return super(lecroy_wavemain, self).ask(command, raw=raw, chunk_size=chunk_size)
     def _snap_png_getdev(self, area='dso', white_back=False):
         """
         Use like this: get(wave.snap_png, filename='testname.png')
@@ -931,7 +931,7 @@ class lecroy_wavemaster(visaInstrumentAsync):
         else:
             raise RuntimeError(self.perror('The channel used for async detect of acquisition number is invalid'))
     def _async_detect(self, max_time=.5): # 0.5 s max by default
-        ret = super(lecroy_wavemaster, self)._async_detect(max_time)
+        ret = super(lecroy_wavemain, self)._async_detect(max_time)
         if not ret:
             # This cycle is not finished
             return ret
@@ -1195,7 +1195,7 @@ class lecroy_wavemaster(visaInstrumentAsync):
         self._devwrap('parameter_fetch', autoinit=False, trig=True)
         self.readval = ReadvalDev(self.fetch)
         # This needs to be last to complete creation
-        super(lecroy_wavemaster, self)._create_devs()
+        super(lecroy_wavemain, self)._create_devs()
 
 # Directory for DISK option can use FLPY, HDD, C, D ...
 # Lots of unknown trig_select modes like cascaded

--- a/pyHegel/instruments/others.py
+++ b/pyHegel/instruments/others.py
@@ -980,7 +980,7 @@ class lakeshore_340(visaInstrument):
         return ret
     def _create_devs(self):
         rev_str = self.ask('rev?')
-        conv = ChoiceMultiple(['master_rev_date', 'master_rev_num', 'master_serial_num', 'sw1', 'input_rev_date',
+        conv = ChoiceMultiple(['main_rev_date', 'main_rev_num', 'main_serial_num', 'sw1', 'input_rev_date',
                          'input_rev_num', 'option_id', 'option_rev_date', 'option_rev_num'], fmts=str)
         rev_dic = conv(rev_str)
         ch_Base = ChoiceStrings('A', 'B')
@@ -1996,7 +1996,7 @@ class MagnetController_SMC(visaInstrument):
                                     3:'Quenched!! and External trip',
                                     4:'Brick trip',
                                     5:'Heatsink overtemperature trip',
-                                    6:'Slave trip',
+                                    6:'Subordinate trip',
                                     7:'Heatsink overvoltage trip'}[error_code%10])
                 # Polarity switch (I/V) != 0. error is only reset once a proper polarity change is performed
                 # i.e. when changing polarity (operating_parameters reverse option)  with I=V=0.
@@ -2091,28 +2091,28 @@ class MagnetController_SMC(visaInstrument):
 #######################################################
 
 class pfeiffer_turbo_loop(threading.Thread):
-    def __init__(self, master):
+    def __init__(self, main):
         super(pfeiffer_turbo_loop, self).__init__()
-        self.master = master
+        self.main = main
         self._stop = False
     def cancel(self):
         self._stop = True
     def run(self):
         # empty buffer
-        self.master.visa.flush(visa_wrap.constants.VI_IO_IN_BUF_DISCARD)
+        self.main.visa.flush(visa_wrap.constants.VI_IO_IN_BUF_DISCARD)
         # trow away first partial data
-        self.master.read()
+        self.main.read()
         while True:
             if self._stop:
                 return
-            string = self.master.read()
-            res = self.master.parse(string)
+            string = self.main.read()
+            res = self.main.parse(string)
             if res is None:
                 continue
             param, data = res
-            #self.master._alldata_lock.acquire()
-            self.master._alldata[param] = data, time.time()
-            #self.master._alldata_lock.release()
+            #self.main._alldata_lock.acquire()
+            self.main._alldata[param] = data, time.time()
+            #self.main._alldata_lock.release()
     def wait(self, timeout=None):
         # we use a the context manager because join uses sleep.
         with _sleep_signal_context_manager():
@@ -2853,7 +2853,7 @@ class ah_2550a_capacitance_bridge(visaInstrumentAsync):
         # flags & 0x10 is ready for command
         if flags & 0x20:
             errors.append('Execution Erro')
-        # flags & 0x40 is Master summary
+        # flags & 0x40 is Main summary
         # flags & 0x80 is message available
         if len(errors):
             return ', '.join(errors)

--- a/pyHegel/instruments_base.py
+++ b/pyHegel/instruments_base.py
@@ -2073,8 +2073,8 @@ class ReadvalDev(BaseDevice):
         if not self._do_local_doc:
             return super(ReadvalDev, self)._get_docstring(added=added)
         else:
-            basename = self._slave_dev.name
-            subdoc = self._slave_dev.__doc__
+            basename = self._subordinate_dev.name
+            subdoc = self._subordinate_dev.__doc__
             doc = """
                   This device behaves like doing a run_and_wait followed by a
                   {0}. When in async mode, it will trigger the device and then do
@@ -2090,19 +2090,19 @@ class ReadvalDev(BaseDevice):
             self._do_local_doc = True
         else:
             self._do_local_doc = False
-        self._slave_dev = dev
+        self._subordinate_dev = dev
         if autoinit is None:
             autoinit = dev._autoinit
         super(ReadvalDev,self).__init__(redir_async=dev, autoinit=autoinit, doc=doc, get_has_check=True, **kwarg)
         self._getdev_p = True
     def _getdev(self, **kwarg):
-        self.instr._async_select([(self._slave_dev, kwarg)])
+        self.instr._async_select([(self._subordinate_dev, kwarg)])
         self.instr.run_and_wait()
-        ret = self._slave_dev.get(**kwarg)
-        self._last_filename = self._slave_dev._last_filename
+        ret = self._subordinate_dev.get(**kwarg)
+        self._last_filename = self._subordinate_dev._last_filename
         return ret
     def getformat(self, **kwarg):
-        d = self._slave_dev.getformat(**kwarg)
+        d = self._subordinate_dev.getformat(**kwarg)
         d['obj'] = self
         return d
 
@@ -2888,7 +2888,7 @@ class Dict_SubDevice(BaseDevice):
         key can be a single value, or a list of values (in which case set/get will work
         on a list)
         force_default, set the default value of force used in check/set.
-            It can be True, False or 'slave' which means to let the subdevice handle the
+            It can be True, False or 'subordinate' which means to let the subdevice handle the
             insertion of the missing parameters
         """
         self._subdevice = subdevice
@@ -2979,7 +2979,7 @@ class Dict_SubDevice(BaseDevice):
                 msg_src = 'element %i'%i
             self._general_check(v, lims=lim, msg_src=msg_src)
         force = self._force_helper(force)
-        allow = {True:True, False:'cache', 'slave':False}[force]
+        allow = {True:True, False:'cache', 'subordinate':False}[force]
         self._check_cache['allow'] = allow
         op = self._check_cache['fnct_str']
         # otherwise, the check will be done by set in _setdev below


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.